### PR TITLE
https://app.clubhouse.io/callstatsio/story/14430/dummy-api-endpoints-to-facilitate-oauth-client-credentials-flow-and-consume-confsummary-notifications

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.6-stretch
+ADD requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
+ADD . /code
+WORKDIR /code
+CMD ["flask", "run", "--host=0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  oauth2:
+    build: .
+    networks:
+      - callstats
+    volumes:
+      - ./:/code
+    ports:
+      - 5000:5000
+    environment:
+      - FLASK_ENV=development
+      - AUTHLIB_INSECURE_TRANSPORT=1
+      - FLASK_DEBUG=1
+
+networks:
+  callstats: {}

--- a/website/oauth2.py
+++ b/website/oauth2.py
@@ -10,6 +10,11 @@ from werkzeug.security import gen_salt
 from .models import db, User
 from .models import OAuth2Client, OAuth2AuthorizationCode, OAuth2Token
 
+class ClientCredentialsGrant(grants.ClientCredentialsGrant):
+    #: Allowed client auth methods for token endpoint
+    TOKEN_ENDPOINT_AUTH_METHODS = [
+        'client_secret_post'
+    ]
 
 class AuthorizationCodeGrant(grants.AuthorizationCodeGrant):
     def create_authorization_code(self, client, grant_user, request):
@@ -75,7 +80,7 @@ def config_oauth(app):
 
     # support all grants
     authorization.register_grant(grants.ImplicitGrant)
-    authorization.register_grant(grants.ClientCredentialsGrant)
+    authorization.register_grant(ClientCredentialsGrant)
     authorization.register_grant(AuthorizationCodeGrant)
     authorization.register_grant(PasswordGrant)
     authorization.register_grant(RefreshTokenGrant)

--- a/website/routes.py
+++ b/website/routes.py
@@ -6,6 +6,11 @@ from authlib.oauth2 import OAuth2Error
 from .models import db, User, OAuth2Client
 from .oauth2 import authorization, require_oauth
 
+import logging
+logformat = '%(asctime)s [%(levelname)s] (%(name)s): %(message)s'
+logging.basicConfig(level=logging.DEBUG, format=logformat)
+log = logging.getLogger(__name__)
+
 
 bp = Blueprint(__name__, 'home')
 
@@ -82,7 +87,9 @@ def authorize():
 
 @bp.route('/oauth/token', methods=['POST'])
 def issue_token():
-    return authorization.create_token_response()
+    response = authorization.create_token_response()
+    log.info(response)
+    return response
 
 
 @bp.route('/oauth/revoke', methods=['POST'])
@@ -95,3 +102,12 @@ def revoke_token():
 def api_me():
     user = current_token.user
     return jsonify(id=user.id, username=user.username)
+
+
+@bp.route('/webhook/callstats/send-log', methods=['POST'])
+@require_oauth()
+def send_log():
+    log.info(request.json)
+    resp = jsonify(success=True)
+    resp.status_code = 200
+    return resp

--- a/website/settings.py
+++ b/website/settings.py
@@ -1,0 +1,7 @@
+OAUTH2_TOKEN_EXPIRES_IN = {
+    'authorization_code': 3600,
+    'urn:ietf:params:oauth:grant-type:jwt-bearer': 3600,
+    'implicit': 3600,
+    'password': 864000,
+    'client_credentials': 3600
+}


### PR DESCRIPTION
1. add Dockerfile and docker-compose.yml
2. make 'client_secret_post' method possible to the '/oauth/token' endpoint
3. add '/webhook/callstats/send-log' endpoint that requires token authentication and logs the payload.
4. token expiration time is 1 hour.